### PR TITLE
Github API accepts an assignee when creating tickets

### DIFF
--- a/trac2issues.py
+++ b/trac2issues.py
@@ -350,7 +350,6 @@ class ImportTickets:
         # Remove bulk-import format stuff that the API can't deal with
         issuedata = copy.deepcopy(out)
         issuedata.pop('creator', None)
-        issuedata.pop('assignee', None)
 
         url = "%s/repos/%s/issues" % (self.github, self.projectPath)
         try:


### PR DESCRIPTION
Github API accepts an assignee when creating tickets, so this is no longer removed from the request.
